### PR TITLE
remove lower bound on shapelet amplitude

### DIFF
--- a/python/lensmodelapi/api/profiles/light.py
+++ b/python/lensmodelapi/api/profiles/light.py
@@ -97,7 +97,7 @@ class Shapelets(LightProfile):
                                DefinitionRange(),
                                latex_str=r"$y_0$"),
             'amps': LinearParameterSet("Set of amplitude values for each shapelet function",
-                               DefinitionRange(min_value=0.0),
+                               DefinitionRange(),
                                latex_str=r"$A$"),
         }
         super().__init__(description, parameters)


### PR DESCRIPTION
Having min_value =0.0 is problematic for 2 reasons.
First, the min_value is a float while the actual "value" is a list (creating an error when using set_point_estimate in parameter.py because `if (self.definition_range.min_value is not None and point_estimate.value < self.definition_range.min_value):` can not use the operand "<" between a list and a float.
Second, some amplitudes of the shapelets can be negative as soon as the whole shapelet set produces a positive surface brightness overall.
I have no better idea then just suppressing the min_value=0.0.