### PR TITLE
import numpy to work with numpy arrays in parameter.py

### DIFF
--- a/python/lensmodelapi/api/parameter.py
+++ b/python/lensmodelapi/api/parameter.py
@@ -5,6 +5,8 @@ from typing import List
 from lensmodelapi.api.base import APIBaseObject
 from lensmodelapi.api.probabilities import Prior, PosteriorStatistics
 
+import numpy as np
+
 
 __all__ = [
     'Parameter',


### PR DESCRIPTION
With the commit a40d11f that solved the issue of list and arrays in parameter.py, there was an import numpy missing.